### PR TITLE
Add Onsen.js #16 and #17 events

### DIFF
--- a/wiki/OnsenJS.md
+++ b/wiki/OnsenJS.md
@@ -71,6 +71,7 @@ meetups:
   - date: '2026-03-13'
     name: 'Onsen.js #16'
     place: Let's Relax Onsen (Lumphini)
+    url: https://www.facebook.com/photo/?fbid=10228131263741021&set=pcb.10228131264501040
   - date: '2026-05-29'
     name: 'Onsen.js #17'
     place: Let's Relax Onsen (Lumphini)

--- a/wiki/OnsenJS.md
+++ b/wiki/OnsenJS.md
@@ -68,6 +68,13 @@ meetups:
     name: 'Onsen.js #15'
     place: Let's Relax Onsen (Ratchadamri)
     url: https://www.facebook.com/photo/?fbid=3354399228080803&set=a.359894480864641
+  - date: '2026-03-13'
+    name: 'Onsen.js #16'
+    place: Let's Relax Onsen (Lumphini)
+  - date: '2026-05-29'
+    name: 'Onsen.js #17'
+    place: Let's Relax Onsen (Lumphini)
+    url: https://www.facebook.com/dtinth/posts/pfbid02qZKbCkrccjkYEn8L6frb6CaJoDqSug8KNLxnKvQj6LvR4QkM3NKxjnTXyxVShRSdl
 ---
 
 :::lead


### PR DESCRIPTION
Add two upcoming Onsen.js events:
- Onsen.js #16 on March 13, 2026 at Let's Relax Onsen (Lumphini)
- Onsen.js #17 on May 29, 2026 at Let's Relax Onsen (Lumphini)

Both events include Facebook event links.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyQXMa6A36rS9RFyuaJawU)_